### PR TITLE
[BE] 추억(Post) 앨범 사진 및 설명을 추가 및 삭제하는 API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,8 @@ dependencies {
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
 
 	implementation 'io.hypersistence:hypersistence-utils-hibernate-63:3.9.0'
+
+	implementation "com.amazonaws:aws-java-sdk-s3:1.12.281"
 }
 
 tasks.named('test') {

--- a/src/main/java/org/hana/wooahhanaapi/domain/plan/controller/PostController.java
+++ b/src/main/java/org/hana/wooahhanaapi/domain/plan/controller/PostController.java
@@ -1,0 +1,27 @@
+package org.hana.wooahhanaapi.domain.plan.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.hana.wooahhanaapi.domain.plan.dto.CreatePostRequestDto;
+import org.hana.wooahhanaapi.domain.plan.dto.CreatePostResponseDto;
+import org.hana.wooahhanaapi.domain.plan.service.PostService;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+
+@RestController
+@RequestMapping("/post")
+@RequiredArgsConstructor
+public class PostController {
+
+    private final PostService postService;
+
+    @PostMapping(value = "/create", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public CreatePostResponseDto createPost(
+            @RequestPart("data") CreatePostRequestDto requestDto,
+            @RequestPart("image") MultipartFile image
+    ) throws IOException {
+        return this.postService.createPost(requestDto, image);
+    }
+}

--- a/src/main/java/org/hana/wooahhanaapi/domain/plan/controller/PostController.java
+++ b/src/main/java/org/hana/wooahhanaapi/domain/plan/controller/PostController.java
@@ -24,4 +24,10 @@ public class PostController {
     ) throws IOException {
         return this.postService.createPost(requestDto, image);
     }
+
+    @DeleteMapping("/{postId}")
+    public String deletePost(@PathVariable String postId) {
+        postService.deletePost(postId);
+        return "Post가 성공적으로 삭제되었습니다.";
+    }
 }

--- a/src/main/java/org/hana/wooahhanaapi/domain/plan/dto/CreatePostRequestDto.java
+++ b/src/main/java/org/hana/wooahhanaapi/domain/plan/dto/CreatePostRequestDto.java
@@ -1,0 +1,16 @@
+package org.hana.wooahhanaapi.domain.plan.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CreatePostRequestDto {
+    private String planId;
+    private String memberId;
+    private String description;
+}

--- a/src/main/java/org/hana/wooahhanaapi/domain/plan/dto/CreatePostResponseDto.java
+++ b/src/main/java/org/hana/wooahhanaapi/domain/plan/dto/CreatePostResponseDto.java
@@ -1,0 +1,21 @@
+package org.hana.wooahhanaapi.domain.plan.dto;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CreatePostResponseDto {
+
+    private String postId;
+    private String imageUrl;
+    private String description;
+
+}

--- a/src/main/java/org/hana/wooahhanaapi/domain/plan/entity/MockPlanEntity.java
+++ b/src/main/java/org/hana/wooahhanaapi/domain/plan/entity/MockPlanEntity.java
@@ -15,7 +15,7 @@ import java.util.UUID;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
-public class PlanEntity {
+public class MockPlanEntity {
     @Id
     @GeneratedValue(strategy= GenerationType.UUID)
     @Column(name="id")

--- a/src/main/java/org/hana/wooahhanaapi/domain/plan/entity/PlanEntity.java
+++ b/src/main/java/org/hana/wooahhanaapi/domain/plan/entity/PlanEntity.java
@@ -1,0 +1,42 @@
+package org.hana.wooahhanaapi.domain.plan.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+//import org.hana.wooahhanaapi.domain.plan.entity.MembershipEntity;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Builder
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PlanEntity {
+    @Id
+    @GeneratedValue(strategy= GenerationType.UUID)
+    @Column(name="id")
+    protected UUID id;
+
+    @Column(nullable=false, name = "title")
+    protected String title;
+
+    @Column(nullable=false, name = "start_date")
+    protected LocalDateTime startDate;
+
+    @Column(nullable=false, name = "end_date")
+    protected LocalDateTime endDate;
+
+    @Column(nullable=false, name = "category")
+    protected String category;
+
+    @Column(nullable = false, name = "location")
+    protected String location;
+
+//    @OneToMany(mappedBy = "plan", cascade = CascadeType.ALL, orphanRemoval = true)
+//    private List<MembershipEntity> memberships; // Plan에 참여한 회원 목록
+
+}

--- a/src/main/java/org/hana/wooahhanaapi/domain/plan/entity/PostEntity.java
+++ b/src/main/java/org/hana/wooahhanaapi/domain/plan/entity/PostEntity.java
@@ -1,0 +1,38 @@
+package org.hana.wooahhanaapi.domain.plan.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hana.wooahhanaapi.domain.member.entity.MemberEntity;
+
+import java.util.UUID;
+
+@Table(name = "post")
+@Entity
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PostEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "plan_id", nullable = false)
+    private PlanEntity plan;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private MemberEntity member;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String imageUrl; // S3 URL 저장
+
+    @Column(length = 255)
+    private String description;
+}
+

--- a/src/main/java/org/hana/wooahhanaapi/domain/plan/entity/PostEntity.java
+++ b/src/main/java/org/hana/wooahhanaapi/domain/plan/entity/PostEntity.java
@@ -23,7 +23,7 @@ public class PostEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "plan_id", nullable = false)
-    private PlanEntity plan;
+    private MockPlanEntity plan;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false)

--- a/src/main/java/org/hana/wooahhanaapi/domain/plan/exception/EntityNotFoundException.java
+++ b/src/main/java/org/hana/wooahhanaapi/domain/plan/exception/EntityNotFoundException.java
@@ -1,0 +1,26 @@
+package org.hana.wooahhanaapi.domain.plan.exception;
+
+import lombok.Getter;
+import org.hana.wooahhanaapi.utils.exception.CustomExceptionData;
+import org.hana.wooahhanaapi.utils.exception.GlobalException;
+import org.springframework.http.HttpStatus;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class EntityNotFoundException extends GlobalException {
+
+    private final HttpStatus httpStatus = HttpStatus.NOT_FOUND;
+    private final LocalDateTime timeStamp = LocalDateTime.now();
+    private final String exceptionName = "Entity Not Found Exception";
+
+    public EntityNotFoundException(String message) {
+        super(message);
+        this.customExceptionData = CustomExceptionData.create(httpStatus, exceptionName);
+    }
+
+    @Override
+    public LocalDateTime getTimeStamp() {
+        return this.timeStamp;
+    }
+}

--- a/src/main/java/org/hana/wooahhanaapi/domain/plan/exception/FileSizeExceededException.java
+++ b/src/main/java/org/hana/wooahhanaapi/domain/plan/exception/FileSizeExceededException.java
@@ -1,0 +1,25 @@
+package org.hana.wooahhanaapi.domain.plan.exception;
+
+import lombok.Getter;
+import org.hana.wooahhanaapi.utils.exception.CustomExceptionData;
+import org.hana.wooahhanaapi.utils.exception.GlobalException;
+import org.springframework.http.HttpStatus;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class FileSizeExceededException extends GlobalException {
+
+    private final HttpStatus httpStatus = HttpStatus.BAD_REQUEST;
+    private final String exceptionName = "File Size Exceeded Exception";
+
+    public FileSizeExceededException(String message) {
+        super(message);
+        this.customExceptionData = CustomExceptionData.create(httpStatus, exceptionName);
+    }
+
+    @Override
+    public LocalDateTime getTimeStamp() {
+        return customExceptionData.getTimestamp();
+    }
+}

--- a/src/main/java/org/hana/wooahhanaapi/domain/plan/exception/InvalidFileTypeException.java
+++ b/src/main/java/org/hana/wooahhanaapi/domain/plan/exception/InvalidFileTypeException.java
@@ -1,0 +1,28 @@
+package org.hana.wooahhanaapi.domain.plan.exception;
+
+import lombok.Getter;
+import org.hana.wooahhanaapi.utils.exception.CustomExceptionData;
+import org.hana.wooahhanaapi.utils.exception.GlobalException;
+import org.springframework.http.HttpStatus;
+
+import java.time.LocalDateTime;
+
+
+@Getter
+public class InvalidFileTypeException extends GlobalException {
+
+    private final HttpStatus httpStatus = HttpStatus.BAD_REQUEST;
+    private final String exceptionName = "Invalid File Type";
+
+    public InvalidFileTypeException(String message) {
+        super(message);
+        this.customExceptionData = CustomExceptionData.create(httpStatus, exceptionName);
+    }
+
+    @Override
+    public LocalDateTime getTimeStamp() {
+        return customExceptionData.getTimestamp();
+    }
+
+
+}

--- a/src/main/java/org/hana/wooahhanaapi/domain/plan/exception/InvalidPostDataException.java
+++ b/src/main/java/org/hana/wooahhanaapi/domain/plan/exception/InvalidPostDataException.java
@@ -1,0 +1,24 @@
+package org.hana.wooahhanaapi.domain.plan.exception;
+
+import lombok.Getter;
+import org.hana.wooahhanaapi.utils.exception.CustomExceptionData;
+import org.hana.wooahhanaapi.utils.exception.GlobalException;
+import org.springframework.http.HttpStatus;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class InvalidPostDataException extends GlobalException {
+    private final HttpStatus httpStatus = HttpStatus.BAD_REQUEST;
+    private final String exceptionName = "Invalid Post Data";
+
+    public InvalidPostDataException(String message) {
+        super(message);
+        this.customExceptionData = CustomExceptionData.create(httpStatus, exceptionName);
+    }
+
+    @Override
+    public LocalDateTime getTimeStamp() {
+        return customExceptionData.getTimestamp();
+    }
+}

--- a/src/main/java/org/hana/wooahhanaapi/domain/plan/repository/PlanRepository.java
+++ b/src/main/java/org/hana/wooahhanaapi/domain/plan/repository/PlanRepository.java
@@ -1,0 +1,9 @@
+package org.hana.wooahhanaapi.domain.plan.repository;
+
+import org.hana.wooahhanaapi.domain.plan.entity.PlanEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface PlanRepository extends JpaRepository<PlanEntity, UUID> {
+}

--- a/src/main/java/org/hana/wooahhanaapi/domain/plan/repository/PlanRepository.java
+++ b/src/main/java/org/hana/wooahhanaapi/domain/plan/repository/PlanRepository.java
@@ -1,9 +1,9 @@
 package org.hana.wooahhanaapi.domain.plan.repository;
 
-import org.hana.wooahhanaapi.domain.plan.entity.PlanEntity;
+import org.hana.wooahhanaapi.domain.plan.entity.MockPlanEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.UUID;
 
-public interface PlanRepository extends JpaRepository<PlanEntity, UUID> {
+public interface PlanRepository extends JpaRepository<MockPlanEntity, UUID> {
 }

--- a/src/main/java/org/hana/wooahhanaapi/domain/plan/repository/PostRepository.java
+++ b/src/main/java/org/hana/wooahhanaapi/domain/plan/repository/PostRepository.java
@@ -1,0 +1,9 @@
+package org.hana.wooahhanaapi.domain.plan.repository;
+
+import org.hana.wooahhanaapi.domain.plan.entity.PostEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface PostRepository extends JpaRepository<PostEntity, UUID> {
+}

--- a/src/main/java/org/hana/wooahhanaapi/domain/plan/service/PostService.java
+++ b/src/main/java/org/hana/wooahhanaapi/domain/plan/service/PostService.java
@@ -1,0 +1,71 @@
+package org.hana.wooahhanaapi.domain.plan.service;
+
+import lombok.RequiredArgsConstructor;
+import org.hana.wooahhanaapi.domain.member.entity.MemberEntity;
+import org.hana.wooahhanaapi.domain.member.repository.MemberRepository;
+import org.hana.wooahhanaapi.domain.plan.dto.CreatePostRequestDto;
+import org.hana.wooahhanaapi.domain.plan.dto.CreatePostResponseDto;
+import org.hana.wooahhanaapi.domain.plan.entity.PlanEntity;
+import org.hana.wooahhanaapi.domain.plan.entity.PostEntity;
+import org.hana.wooahhanaapi.domain.plan.exception.*;
+import org.hana.wooahhanaapi.domain.plan.repository.PlanRepository;
+import org.hana.wooahhanaapi.domain.plan.repository.PostRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.Objects;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class PostService {
+    private final S3Service s3Service;
+    private final PlanRepository planRepository;
+    private final MemberRepository memberRepository;
+    private final PostRepository postRepository;
+
+    public CreatePostResponseDto createPost(CreatePostRequestDto requestDto, MultipartFile image) throws IOException {
+
+        // 값이 들어있는지 확인
+        if (requestDto.getPlanId() == null || requestDto.getMemberId() == null || requestDto.getDescription() == null
+                ||image == null || image.isEmpty()) {
+            throw new InvalidPostDataException("필수 데이터가 누락되었습니다.");
+        }
+
+        // 이미지 파일 형식 확인
+        if (!Objects.requireNonNull(image.getContentType()).startsWith("image/")) {
+            throw new InvalidFileTypeException("지원되지 않는 파일 형식입니다.");
+        }
+
+        // 파일 크기 10MB 제한
+        if (image.getSize() > 10 * 1024 * 1024) {
+            throw new FileSizeExceededException("업로드 가능한 파일 크기를 초과했습니다.");
+        }
+
+        PlanEntity plan = planRepository.findById(UUID.fromString(requestDto.getPlanId()))
+                .orElseThrow(() -> new EntityNotFoundException("해당 Plan이 존재하지 않습니다."));
+
+        MemberEntity member = memberRepository.findById(UUID.fromString(requestDto.getMemberId()))
+                .orElseThrow(() -> new EntityNotFoundException("해당 Member가 존재하지 않습니다."));
+
+        String s3FileName = UUID.randomUUID() + "-" + image.getOriginalFilename();
+        /* 임시로 S3 url 대신 fileName으로 db 저장" */
+//        String imageUrl = s3Service.upload(image, s3FileName);
+        String imageUrl = s3FileName;
+
+        PostEntity post = PostEntity.builder()
+                .plan(plan)
+                .member(member)
+                .imageUrl(imageUrl)
+                .description(requestDto.getDescription())
+                .build();
+        postRepository.save(post);
+
+        return CreatePostResponseDto.builder()
+                .postId(post.getId().toString())
+                .imageUrl(post.getImageUrl())
+                .description(post.getDescription())
+                .build();
+    }
+}

--- a/src/main/java/org/hana/wooahhanaapi/domain/plan/service/PostService.java
+++ b/src/main/java/org/hana/wooahhanaapi/domain/plan/service/PostService.java
@@ -6,7 +6,7 @@ import org.hana.wooahhanaapi.domain.member.entity.MemberEntity;
 import org.hana.wooahhanaapi.domain.member.repository.MemberRepository;
 import org.hana.wooahhanaapi.domain.plan.dto.CreatePostRequestDto;
 import org.hana.wooahhanaapi.domain.plan.dto.CreatePostResponseDto;
-import org.hana.wooahhanaapi.domain.plan.entity.PlanEntity;
+import org.hana.wooahhanaapi.domain.plan.entity.MockPlanEntity;
 import org.hana.wooahhanaapi.domain.plan.entity.PostEntity;
 import org.hana.wooahhanaapi.domain.plan.exception.*;
 import org.hana.wooahhanaapi.domain.plan.repository.PlanRepository;
@@ -44,7 +44,7 @@ public class PostService {
             throw new FileSizeExceededException("업로드 가능한 파일 크기를 초과했습니다.");
         }
 
-        PlanEntity plan = planRepository.findById(UUID.fromString(requestDto.getPlanId()))
+        MockPlanEntity plan = planRepository.findById(UUID.fromString(requestDto.getPlanId()))
                 .orElseThrow(() -> new EntityNotFoundException("해당 Plan이 존재하지 않습니다."));
 
         MemberEntity member = memberRepository.findById(UUID.fromString(requestDto.getMemberId()))

--- a/src/main/java/org/hana/wooahhanaapi/domain/plan/service/PostService.java
+++ b/src/main/java/org/hana/wooahhanaapi/domain/plan/service/PostService.java
@@ -1,5 +1,6 @@
 package org.hana.wooahhanaapi.domain.plan.service;
 
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.hana.wooahhanaapi.domain.member.entity.MemberEntity;
 import org.hana.wooahhanaapi.domain.member.repository.MemberRepository;
@@ -67,5 +68,16 @@ public class PostService {
                 .imageUrl(post.getImageUrl())
                 .description(post.getDescription())
                 .build();
+    }
+
+    @Transactional
+    public void deletePost(String postId) {
+        PostEntity post = postRepository.findById(UUID.fromString(postId))
+                .orElseThrow(() -> new EntityNotFoundException("해당 Post를 찾을 수 없습니다."));
+
+        String fileUrl = post.getImageUrl();
+//        s3Service.delete(fileUrl);
+
+        postRepository.delete(post);
     }
 }

--- a/src/main/java/org/hana/wooahhanaapi/domain/plan/service/S3Service.java
+++ b/src/main/java/org/hana/wooahhanaapi/domain/plan/service/S3Service.java
@@ -1,0 +1,41 @@
+package org.hana.wooahhanaapi.domain.plan.service;
+
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
+@Log4j2
+@RequiredArgsConstructor
+@Service
+public class S3Service {
+//    @Value("${cloud.aws.s3.bucket}")
+//    private String bucket;
+
+//    private final AmazonS3 amazonS3;
+
+    public String upload(MultipartFile multipartFile, String s3FileName) throws IOException {
+
+        String encodedFileName = URLEncoder.encode(s3FileName, StandardCharsets.UTF_8);
+        ObjectMetadata objMeta = new ObjectMetadata();
+        objMeta.setContentLength(multipartFile.getInputStream().available());
+        // 파일의 MIME 타입 설정
+        objMeta.setContentType(multipartFile.getContentType());
+        try{
+//            amazonS3.putObject(bucket, encodedFileName, multipartFile.getInputStream(), objMeta);
+        }catch (AmazonServiceException e) {
+            log.error("S3 파일 업로드 중 오류 발생: {}", e.getMessage(), e);
+        }
+
+//        return amazonS3.getUrl(bucket, encodedFileName).toString();
+          return "url";
+    }
+}

--- a/src/main/java/org/hana/wooahhanaapi/domain/plan/service/S3Service.java
+++ b/src/main/java/org/hana/wooahhanaapi/domain/plan/service/S3Service.java
@@ -38,4 +38,14 @@ public class S3Service {
 //        return amazonS3.getUrl(bucket, encodedFileName).toString();
           return "url";
     }
+
+    public void delete(String fileUrl) {
+        try {
+            // ".com/" 이후의 파일명을 추출
+            String keyName = fileUrl.substring(fileUrl.indexOf(".com/") + 5);
+//            amazonS3.deleteObject(bucket, keyName);
+        } catch (AmazonServiceException e) {
+            log.error("S3 파일 삭제 중 오류 발생: {}", e.toString());
+        }
+    }
 }


### PR DESCRIPTION
- 변경사항
1. PostEntity에 post(사진 및 설명) 저장
2. PostEntity에서 post(사진 및 설명) 삭제

- 공유할 사항
1. S3 저장 및 삭제 로직 완성
2. aws key 문제로 해당 로직 주석처리 => DB 저장만 일단 가능
3. DB img_url 에 임시로 file 명만 저장
4. PlanEntity 임시 생성 => 수정된 후 반영 예정