### PR TITLE
WA-63 [BE] 관리자가 회비 입금 현황 확인하는 API

### DIFF
--- a/src/main/java/org/hana/wooahhanaapi/domain/account/adapter/dto/AccountTransferRecordReqDto.java
+++ b/src/main/java/org/hana/wooahhanaapi/domain/account/adapter/dto/AccountTransferRecordReqDto.java
@@ -16,14 +16,22 @@ public class AccountTransferRecordReqDto {
 
     private String bankTranId;
     private String accountNumber;
-    private String fintechUseNum;
-    private String inquiryType;
-    private String inquiryBase;
+    @Builder.Default
+    private String fintechUseNum = "fintech_use_num";
+    @Builder.Default
+    private String inquiryType = "00";
+    @Builder.Default
+    private String inquiryBase = "00";
     private String fromDate;
-    private String fromTime;
+    @Builder.Default
+    private String fromTime = "00:00";
     private String toDate;
-    private String toTime;
-    private String sortOrder;
-    private String tranDtime;
-    private String beforeInquiryTraceInfo;
+    @Builder.Default
+    private String toTime = "23:59";
+    @Builder.Default
+    private String sortOrder = "asc";
+    @Builder.Default
+    private String tranDtime = "00";
+    @Builder.Default
+    private String beforeInquiryTraceInfo = "00";
 }

--- a/src/main/java/org/hana/wooahhanaapi/domain/community/controller/CommunityController.java
+++ b/src/main/java/org/hana/wooahhanaapi/domain/community/controller/CommunityController.java
@@ -5,6 +5,8 @@ import org.hana.wooahhanaapi.domain.account.adapter.dto.AccountValidationConfirm
 import org.hana.wooahhanaapi.domain.account.adapter.dto.AccountValidationReqDto;
 import org.hana.wooahhanaapi.domain.community.dto.CommunityChgManagerReqDto;
 import org.hana.wooahhanaapi.domain.community.dto.CommunityCreateReqDto;
+import org.hana.wooahhanaapi.domain.community.dto.CommunityFeeStatusReqDto;
+import org.hana.wooahhanaapi.domain.community.dto.CommunityFeeStatusRespDto;
 import org.hana.wooahhanaapi.domain.community.service.CommunityService;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -35,10 +37,17 @@ public class CommunityController {
 //        return this.communityService.validateAccountConfirm(dto);
 //    }
 
+    // 모임 계주 변경
     @PostMapping("/changeManager")
     public String changeManager(@RequestBody CommunityChgManagerReqDto dto) {
         this.communityService.changeCommunityManager(dto);
         return "success";
+    }
+
+    // 회비 입금 현황
+    @PostMapping("/feeStatus")
+    public CommunityFeeStatusRespDto feeStatus(@RequestBody CommunityFeeStatusReqDto dto) {
+        return this.communityService.checkFeeStatus(dto);
     }
 
 }

--- a/src/main/java/org/hana/wooahhanaapi/domain/community/dto/CommunityFeeStatusReqDto.java
+++ b/src/main/java/org/hana/wooahhanaapi/domain/community/dto/CommunityFeeStatusReqDto.java
@@ -1,0 +1,20 @@
+package org.hana.wooahhanaapi.domain.community.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class CommunityFeeStatusReqDto {
+
+    private UUID communityId;
+}

--- a/src/main/java/org/hana/wooahhanaapi/domain/community/dto/CommunityFeeStatusRespDto.java
+++ b/src/main/java/org/hana/wooahhanaapi/domain/community/dto/CommunityFeeStatusRespDto.java
@@ -1,0 +1,22 @@
+package org.hana.wooahhanaapi.domain.community.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Set;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class CommunityFeeStatusRespDto {
+
+    private Set<CommunityFeeStatusRespListDto> paidMembers;
+    private Set<CommunityFeeStatusRespListDto> unpaidMembers;
+
+}

--- a/src/main/java/org/hana/wooahhanaapi/domain/community/dto/CommunityFeeStatusRespListDto.java
+++ b/src/main/java/org/hana/wooahhanaapi/domain/community/dto/CommunityFeeStatusRespListDto.java
@@ -1,0 +1,19 @@
+package org.hana.wooahhanaapi.domain.community.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class CommunityFeeStatusRespListDto {
+
+    private String memberName;
+    private Long amount;
+}

--- a/src/main/java/org/hana/wooahhanaapi/domain/community/repository/MembershipRepository.java
+++ b/src/main/java/org/hana/wooahhanaapi/domain/community/repository/MembershipRepository.java
@@ -11,4 +11,5 @@ import java.util.UUID;
 
 public interface MembershipRepository extends JpaRepository<MembershipEntity, UUID> {
     List<MembershipEntity> findAllByMemberAndCommunity(MemberEntity member, CommunityEntity community);
+    List<MemberEntity> findMembersByCommunityId(UUID communityId);
 }


### PR DESCRIPTION
ex) 매월 5일 입금, 오늘은 1월 13일 -> 1월 5일 ~ 1월 13일까지의 거래 내역 확인
ex) 매월 15일 입금, 오늘은 1월 13일 -> 12월 15일 ~ 1월 13일까지의 거래 내역 확인
print_content가 **멤버 이름**이여야 납부 여부를 체크할 수 있도록 구현 -> 입금자명은 멤버 이름이여야
멤버 이름을 key로 하는 hashmap으로 입금액 누적 -> 누적 입금액이 커뮤니티에 설정한 fee를 넘어설 때 납입으로 체크
-> 그렇지 않으면 미납입